### PR TITLE
Restore popup UI and manifest entries

### DIFF
--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -1,6 +1,7 @@
 (() => {
-  // Counter for detected images
-  let imgCount = 0;
+  const run = () => {
+    // Counter for detected images
+    let imgCount = 0;
 
   // 1. Create the info panel
   const panel = document.createElement('div');
@@ -67,4 +68,11 @@
     }
   });
   mo.observe(document.body, { childList: true, subtree: true });
+  };
+
+  chrome.storage.local.get({ enabled: true }, (res) => {
+    if (res.enabled) {
+      run();
+    }
+  });
 })();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,11 @@
   "version": "1.1",
   "description": "Detect large images (>=1080x1080) and list them in an on-page panel.",
   "manifest_version": 3,
-  "permissions": [],
+  "permissions": ["storage"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Image Size Checker"
+  },
   "content_scripts": [
     {
       "matches": ["<all_urls>"],

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,24 @@
+<html>
+<head>
+  <meta charset="utf-8" />
+  <style>
+    body {
+      min-width: 200px;
+      font-family: sans-serif;
+      padding: 10px;
+    }
+    label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 14px;
+    }
+  </style>
+</head>
+<body>
+  <label>
+    <input type="checkbox" id="toggle" /> Ativar detecção
+  </label>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const checkbox = document.getElementById('toggle');
+  chrome.storage.local.get({ enabled: true }, (res) => {
+    checkbox.checked = res.enabled;
+  });
+
+  checkbox.addEventListener('change', () => {
+    chrome.storage.local.set({ enabled: checkbox.checked });
+  });
+});


### PR DESCRIPTION
## Summary
- restore popup.html and popup.js with UI checkbox to enable detection
- add action and storage permission back to `manifest.json`
- show the info panel only when enabled in `chrome.storage`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68566e03b870832cbc4ba29c1094d758